### PR TITLE
Fix typo in vite config comment

### DIFF
--- a/chocotto-optimizer/vite.config.ts
+++ b/chocotto-optimizer/vite.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
         // Preload scripts may contain Web assets, so use the `build.rollupOptions.input` instead `build.lib.entry`.
         input: path.join(__dirname, 'electron/preload.ts'),
       },
-      // Ployfill the Electron and Node.js API for Renderer process.
+      // Polyfill the Electron and Node.js API for Renderer process.
       // If you want use Node.js in Renderer process, the `nodeIntegration` needs to be enabled in the Main process.
       // See 👉 https://github.com/electron-vite/vite-plugin-electron-renderer
       renderer: process.env.NODE_ENV === 'test'


### PR DESCRIPTION
## Summary
- correct `Polyfill` comment in `vite.config.ts`

## Testing
- `grep -n "Polyfill" chocotto-optimizer/vite.config.ts`


------
https://chatgpt.com/codex/tasks/task_e_68401b949e9083219b3843c7bc1c8d55