### PR TITLE
テストカバレッジ向上

### DIFF
--- a/chocotto-optimizer/test/dto.test.ts
+++ b/chocotto-optimizer/test/dto.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { EquipmentDTO } from '../electron/modules/dto';
+import { 武器, 盾 } from './testConst';
+
+describe('EquipmentDTO mannequin conversions', () => {
+  it('convertCharacterEquippedToMannequin and back', () => {
+    const weaponInstance = EquipmentDTO.convertEquipmentToEquipmentInstance(武器.銅の剣);
+    const shieldInstance = EquipmentDTO.convertEquipmentToEquipmentInstance(盾.赤薔薇のミュルグレス);
+    const mainEquipped = { '武器': weaponInstance, '盾': shieldInstance };
+    const subEquipped = {};
+
+    const mannequin = EquipmentDTO.convertCharacterEquippedToMannequin(mainEquipped, subEquipped);
+    const { main, sub } = EquipmentDTO.convertMannequinToCharacterEquipped(mannequin, [weaponInstance, shieldInstance]);
+
+    expect(main).toEqual(mainEquipped);
+    expect(sub).toEqual(subEquipped);
+  });
+});

--- a/chocotto-optimizer/test/pathUtils.test.ts
+++ b/chocotto-optimizer/test/pathUtils.test.ts
@@ -1,0 +1,44 @@
+import path from 'path';
+import { describe, it, expect, afterEach } from 'vitest';
+import { getAppDataPath } from '../electron/modules/pathUtils';
+
+type DummyApp = { isPackaged: boolean; getPath: (type: string) => string };
+
+const originalEnv = { ...process.env };
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+});
+
+describe('getAppDataPath', () => {
+  it('returns dev path when VITE_DEV_SERVER_URL is set', () => {
+    process.env.VITE_DEV_SERVER_URL = 'true';
+    const app: DummyApp = { isPackaged: false, getPath: () => '' };
+    const result = getAppDataPath(app as any);
+    expect(result).toBe(path.join(process.cwd(), 'data'));
+  });
+
+  it('returns portable path when packaged and PORTABLE_EXECUTABLE_DIR is set', () => {
+    delete process.env.VITE_DEV_SERVER_URL;
+    process.env.PORTABLE_EXECUTABLE_DIR = '/portable';
+    const app: DummyApp = { isPackaged: true, getPath: () => '' };
+    const result = getAppDataPath(app as any);
+    expect(result).toBe(path.join('/portable', 'data'));
+  });
+
+  it('returns execPath dir when packaged without portable dir', () => {
+    delete process.env.VITE_DEV_SERVER_URL;
+    delete process.env.PORTABLE_EXECUTABLE_DIR;
+    const app: DummyApp = { isPackaged: true, getPath: () => process.execPath };
+    const expected = path.join(path.dirname(process.execPath), 'data');
+    const result = getAppDataPath(app as any);
+    expect(result).toBe(expected);
+  });
+
+  it('returns default path when not packaged', () => {
+    delete process.env.VITE_DEV_SERVER_URL;
+    const app: DummyApp = { isPackaged: false, getPath: () => '' };
+    const result = getAppDataPath(app as any);
+    expect(result).toBe(path.join(process.cwd(), 'data'));
+  });
+});

--- a/chocotto-optimizer/test/writer.extra.test.ts
+++ b/chocotto-optimizer/test/writer.extra.test.ts
@@ -1,0 +1,39 @@
+import fs from 'fs';
+import { describe, it, expect, afterEach } from 'vitest';
+import { writeCharacterStatusToJSON, writeAvatarStatusToJSON, writeMannequinToJSON } from '../electron/modules/writer';
+import { CharacterStatus, AvatarStatus, Mannequin } from '../types/types';
+
+const charPath = './test/data/writeCharacterStatusToJSON.json';
+const avatarPath = './test/data/writeAvatarStatusToJSON.json';
+const mannequinPath = './test/data/writeMannequinToJSON.json';
+
+afterEach(() => {
+  [charPath, avatarPath, mannequinPath].forEach((p) => {
+    if (fs.existsSync(p)) {
+      fs.unlinkSync(p);
+    }
+  });
+});
+
+describe('writer additional functions', () => {
+  it('writeCharacterStatusToJSON', () => {
+    const status: CharacterStatus = { lv: 10, hp: 100, sp: 50, pow: 1, int: 2, vit: 3, spd: 4, luk: 5 };
+    writeCharacterStatusToJSON(charPath, status);
+    const parsed = JSON.parse(fs.readFileSync(charPath, 'utf8'));
+    expect(parsed).toEqual(status);
+  });
+
+  it('writeAvatarStatusToJSON', () => {
+    const status: AvatarStatus = { pow: 1, int: 2, vit: 3, spd: 4, luk: 5, hp: 100, sp: 50, atk: 10, def: 11, mat: 12, mdf: 13, hpr: 14, spr: 15, exp: 16, pet: 17, mov: 18, drn: 19 };
+    writeAvatarStatusToJSON(avatarPath, status);
+    const parsed = JSON.parse(fs.readFileSync(avatarPath, 'utf8'));
+    expect(parsed).toEqual(status);
+  });
+
+  it('writeMannequinToJSON', () => {
+    const mannequin: Mannequin = { main: {}, sub: {} };
+    writeMannequinToJSON(mannequinPath, mannequin);
+    const parsed = JSON.parse(fs.readFileSync(mannequinPath, 'utf8'));
+    expect(parsed).toEqual(mannequin);
+  });
+});


### PR DESCRIPTION
## 変更点
- DTO 変換処理の往復を確認するテストを追加
- パス取得ユーティリティ `getAppDataPath` の分岐をテスト
- JSON 書き込み系ユーティリティのテストを拡充

## テスト結果
- `pnpm test:coverage` 実行で全 31.51% のカバレッジを確認


------
https://chatgpt.com/codex/tasks/task_e_6843baa85da88321ae8e8be340a1e625