### PR TITLE
Fix pathUtils test typing

### DIFF
--- a/chocotto-optimizer/test/pathUtils.test.ts
+++ b/chocotto-optimizer/test/pathUtils.test.ts
@@ -1,8 +1,9 @@
 import path from 'path';
 import { describe, it, expect, afterEach } from 'vitest';
 import { getAppDataPath } from '../electron/modules/pathUtils';
+import type { App } from 'electron';
 
-type DummyApp = { isPackaged: boolean; getPath: (type: string) => string };
+type DummyApp = Pick<App, 'isPackaged' | 'getPath'>;
 
 const originalEnv = { ...process.env };
 
@@ -14,7 +15,7 @@ describe('getAppDataPath', () => {
   it('returns dev path when VITE_DEV_SERVER_URL is set', () => {
     process.env.VITE_DEV_SERVER_URL = 'true';
     const app: DummyApp = { isPackaged: false, getPath: () => '' };
-    const result = getAppDataPath(app as any);
+    const result = getAppDataPath(app as unknown as App);
     expect(result).toBe(path.join(process.cwd(), 'data'));
   });
 
@@ -22,7 +23,7 @@ describe('getAppDataPath', () => {
     delete process.env.VITE_DEV_SERVER_URL;
     process.env.PORTABLE_EXECUTABLE_DIR = '/portable';
     const app: DummyApp = { isPackaged: true, getPath: () => '' };
-    const result = getAppDataPath(app as any);
+    const result = getAppDataPath(app as unknown as App);
     expect(result).toBe(path.join('/portable', 'data'));
   });
 
@@ -31,14 +32,14 @@ describe('getAppDataPath', () => {
     delete process.env.PORTABLE_EXECUTABLE_DIR;
     const app: DummyApp = { isPackaged: true, getPath: () => process.execPath };
     const expected = path.join(path.dirname(process.execPath), 'data');
-    const result = getAppDataPath(app as any);
+    const result = getAppDataPath(app as unknown as App);
     expect(result).toBe(expected);
   });
 
   it('returns default path when not packaged', () => {
     delete process.env.VITE_DEV_SERVER_URL;
     const app: DummyApp = { isPackaged: false, getPath: () => '' };
-    const result = getAppDataPath(app as any);
+    const result = getAppDataPath(app as unknown as App);
     expect(result).toBe(path.join(process.cwd(), 'data'));
   });
 });


### PR DESCRIPTION
## Summary
- update import and type usage in `pathUtils.test.ts`
- run eslint to verify no `no-explicit-any` issues

## Testing
- `pnpm install`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6843c3488a2483219d6daa702c1f7022